### PR TITLE
Pass logged in users through in token decorator.

### DIFF
--- a/tokenapi/decorators.py
+++ b/tokenapi/decorators.py
@@ -14,6 +14,11 @@ def token_required(view_func):
         token = None
         basic_auth = request.META.get('HTTP_AUTHORIZATION')
 
+        if request.user:
+            if request.user.is_authenticated():
+                # Already logged in, just return the result of the view
+                return view_func(request, *args, **kwargs)
+
         if basic_auth:
             auth_method, auth_string = basic_auth.split(' ', 1)
 


### PR DESCRIPTION
If users have already logged in (with a session cookie for example), this patch
passes them through. This is useful for users who are logged in in a browser
making an AJAX request, or in tests.
