### PR TITLE
Python 3 compatibility update

### DIFF
--- a/tokenapi/tokens.py
+++ b/tokenapi/tokens.py
@@ -49,9 +49,9 @@ class TokenGenerator(object):
 
         # No longer using last login time
         from hashlib import sha1
-        hash = sha1((settings.SECRET_KEY + str(user.id) +
+        hash = sha1((settings.SECRET_KEY + str(user.id).encode('utf-8')) +
             user.password + 
-            str(timestamp)).encode('utf-8')).hexdigest()[::2]
+            str(timestamp).encode('utf-8')).hexdigest()[::2]
         return "%s-%s" % (ts_b36, hash)
 
     def _num_days(self, dt):


### PR DESCRIPTION
changed from unicode() to .encode(), compatible in both python 2 and 3. I'm sure there are more python 3 errors, I'll fix them as I work more with this.
