### PR TITLE
Fix a bug for UUID type IDs

### DIFF
--- a/tokenapi/views.py
+++ b/tokenapi/views.py
@@ -31,10 +31,15 @@ def token_new(request):
 
                 if TOKEN_CHECK_ACTIVE_USER and not user.is_active:
                     return JsonResponseForbidden("User account is disabled.")
-
+                
+                if type(user.pk) == int:
+                    user_pk = user.pk
+                else:
+                    user_pk = str(user.pk)
+                    
                 data = {
                     'token': token_generator.make_token(user),
-                    'user': user.pk,
+                    'user': user_pk,
                 }
                 return JsonResponse(data)
             else:


### PR DESCRIPTION
Hi,

I have overridden my `id` or `pk` field to be Django 1.8's UUIDField. It is NOT JSON serializable. So I suggest this change. Do you think doing this is okay?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jpulgarin/django-tokenapi/25)
<!-- Reviewable:end -->
