### PR TITLE
Replace deprecated `request.REQUEST`

### DIFF
--- a/tokenapi/decorators.py
+++ b/tokenapi/decorators.py
@@ -14,8 +14,8 @@ def token_required(view_func):
         token = None
         basic_auth = request.META.get('HTTP_AUTHORIZATION')
 
-        user = request.REQUEST.get('user')
-        token = request.REQUEST.get('token')
+        user = request.POST.get('user', request.GET.get('user'))
+        token = request.POST.get('token', request.GET.get('token'))
 
         if not (user and token) and basic_auth:
             auth_method, auth_string = basic_auth.split(' ', 1)


### PR DESCRIPTION
The `request.REQUEST` method is deprecated since version 1.7:
https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest.REQUEST
So replace it with  using `request.POST` and `request.GET` explicitly to do same thing.