### PR TITLE
Added python3 handling of basic authorization header

### DIFF
--- a/tokenapi/decorators.py
+++ b/tokenapi/decorators.py
@@ -1,6 +1,8 @@
 from django.http import HttpResponseForbidden
 from django.contrib.auth import authenticate, login
 from django.views.decorators.csrf import csrf_exempt
+from base64 import b64decode
+from sys import version_info
 
 from functools import wraps
 
@@ -21,7 +23,11 @@ def token_required(view_func):
             auth_method, auth_string = basic_auth.split(' ', 1)
 
             if auth_method.lower() == 'basic':
-                auth_string = auth_string.strip().decode('base64')
+                if version_info < (3, 0):
+                    auth_string = auth_string.strip().decode('Base64')
+                else:
+                    auth_string = b64decode(auth_string.strip().encode('utf-8')).decode('utf-8')
+                    
                 user, token = auth_string.split(':', 1)
 
         if not (user and token):


### PR DESCRIPTION
Currently decorators use str.decode, which isn't available in Python3. This handles that, although to actually get it working correctly was a little hacky. There might be a better way, but this seems to work. 