### PR TITLE
fixed references to pk on the user

### DIFF
--- a/tokenapi/backends.py
+++ b/tokenapi/backends.py
@@ -11,9 +11,9 @@ else:
 
 
 class TokenBackend(ModelBackend):
-    def authenticate(self, pk, token):
+    def authenticate(self, username, token):
         try:
-            user = User.objects.get(pk=pk)
+            user = User.objects.get(username=username)
         except User.DoesNotExist:
             return None
 

--- a/tokenapi/decorators.py
+++ b/tokenapi/decorators.py
@@ -27,7 +27,7 @@ def token_required(view_func):
         if not (user and token):
             return HttpResponseForbidden("Must include 'user' and 'token' parameters with request.")
 
-        user = authenticate(pk=user, token=token)
+        user = authenticate(username=user, token=token)
         if user:
             login(request, user)
             return view_func(request, *args, **kwargs)


### PR DESCRIPTION
a username and token must always be passed however it refers to pk instead of username when attempting to authenticate which breaks as soon as it attempts to search for the primary key on the model (in my case an auto incremented number) with the username variable

I changed the model to filter on username rather than primary key to resolve datatype mismatching