### PR TITLE
Pass status to JsonResponse in JsonError

### DIFF
--- a/tokenapi/http.py
+++ b/tokenapi/http.py
@@ -27,7 +27,7 @@ def JsonError(error_string, status=200):
         'success': False,
         'errors': error_string,
     }
-    return JSONResponse(data)
+    return JsonResponse(data, status=status)
 
 
 def JsonResponseBadRequest(error_string):


### PR DESCRIPTION
Currently none of `JsonResponse*` methods actually set the correct status code on the response since the status kwargs is not being passed to the underlying `JsonResponse` method. This PR fixes that.