### PR TITLE
Use DjangoJSONEncoder instead of the default Python json encoder

### DIFF
--- a/tokenapi/http.py
+++ b/tokenapi/http.py
@@ -1,6 +1,7 @@
 """JSON helper functions"""
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 
 
@@ -13,7 +14,7 @@ def JsonResponse(data, dump=True, status=200):
         pass
 
     return HttpResponse(
-        json.dumps(data) if dump else data,
+        json.dumps(data, cls=DjangoJSONEncoder) if dump else data,
         content_type='application/json',
         status=status,
     )


### PR DESCRIPTION
Use DjangoJSONEncoder instead of the default Python json encoder which provides additional support for the serialization of datetime, time, date, Decimal and Promise datetypes.
https://docs.djangoproject.com/en/1.10/topics/serialization/#djangojsonencoder