### PR TITLE
Add support for Django 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='julian@pulgarin.co',
     url='https://github.com/jpulgarin/django-tokenapi',
     packages=['tokenapi'],
+    install_requires=['six'],
     license='Apache License, Version 2.0',
     classifiers=[
         "Programming Language :: Python :: 2.7",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='django-tokenapi',
-    version='1.2',
+    version='1.3',
     description='Add an API to your Django app using token-based authentication.',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",

--- a/tokenapi/tokens.py
+++ b/tokenapi/tokens.py
@@ -1,10 +1,10 @@
 """django.contrib.auth.tokens, but without using last_login in hash"""
 
+import six
 from datetime import date
 from django.conf import settings
 from django.utils.http import int_to_base36, base36_to_int
 from django.utils.crypto import constant_time_compare, salted_hmac
-from django.utils import six
 
 
 class PasswordResetTokenGenerator(object):


### PR DESCRIPTION
Django 3 removed private Python 2 compatibility libs.

https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis